### PR TITLE
Log error code in SharedConfig CA

### DIFF
--- a/iisca/lib/config_custom.cpp
+++ b/iisca/lib/config_custom.cpp
@@ -19,7 +19,7 @@ CheckForSharedConfigurationCA(
     hr = GetSharedConfigEnabled( &fIsSharedConfig );
     if ( FAILED( hr ) )
     {
-        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Unable to detect whether shared configuration is in use.");
+        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Unable to detect whether shared configuration is in use (hr=0x%x).", hr);
         status = LogMsiCustomActionError( hInstall, 30001 );
         goto exit;
     }


### PR DESCRIPTION
### Issue
CheckForSharedConfigurationCA calls GetSharedConfigEnabled to get shared configuration state. This methods fails intermittently but the error code is not being logged.

### Fix
Log the error code when GetSharedConfigEnabled fails.