### PR TITLE
Fix CodeQL bugs in IIS Setup

### DIFF
--- a/iisca/lib/consoleprops.cpp
+++ b/iisca/lib/consoleprops.cpp
@@ -537,7 +537,12 @@ ExecuteSetConsolePropertiesCA(
 			if ( FAILED(hr) || (NULL == pConsoleProps) )
 			{
 				// Create new console properties and set defaults
-				pConsoleProps = (NT_CONSOLE_PROPS *)malloc(sizeof(NT_CONSOLE_PROPS));
+				if ((pConsoleProps = (NT_CONSOLE_PROPS *)malloc(sizeof(NT_CONSOLE_PROPS))) == NULL)
+				{
+					hr = E_OUTOFMEMORY;
+					DBGERROR_HR(hr);
+					goto exit;
+				}
 				memset(pConsoleProps,0,sizeof(NT_CONSOLE_PROPS));
 				IntializeConsoleProps(pConsoleProps);
 			}

--- a/iisca/lib/setup_log.cpp
+++ b/iisca/lib/setup_log.cpp
@@ -83,9 +83,6 @@ Return Value:
     DWORD dwBufLen    = strMsiRegKey.QuerySizeCCH(); 
     DWORD status      = ERROR_SUCCESS;
     HKEY  hKey        = NULL;
-    
-    //for checking logging level
-    WORD i;
 
     //
     //Set MSI handle & CA name
@@ -141,12 +138,9 @@ Return Value:
    
         if ( !( status != ERROR_SUCCESS ) || ( dwBufLen > strMsiRegKey.QuerySizeCCH() ) )
         {
-            //
-            //Have Logging key Value.. we will log something
-            //
             // Check logging flags for verbosity 'v'
             //
-            for ( i = 0; i < strMsiRegKey.QueryCCH() ; i++ )
+            for ( DWORD i = 0; i < strMsiRegKey.QueryCCH() ; i++ )
             {
                 if ( strMsiRegKey.QueryStr()[ i ] == L'V' || strMsiRegKey.QueryStr()[ i ] == L'v' )
                 {


### PR DESCRIPTION
AB#1691426
AB#1691408

Fix CodeQL.SM01928 [Comparison of narrow type with wide type] and CodeQL.SM02311 [NULL dereferenced unconditionally] bugs in IIS.Setup.