### PR TITLE
Changes for ARM64 OOB installers

### DIFF
--- a/appsearch/appsearch.wxi
+++ b/appsearch/appsearch.wxi
@@ -95,4 +95,15 @@
         <Property Id="WEBPI4INSTALLED" Secure="yes">
             <RegistrySearch Id="RegistrySearch_WEBPI4INSTALLED" Type="raw" Root="HKLM" Key="SOFTWARE\Microsoft\WebPlatformInstaller\4" Name="Install" Win64="$(var.IsWin64)"/>
         </Property>
+
+        <!-- Read the processor architecture -->        
+        <Property Id="PROCESSORARCHITECTURE">
+            <RegistrySearch
+                Id="ProcessorArchitectureCheck"
+                Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+                Name="PROCESSOR_ARCHITECTURE"
+                Root="HKLM"
+                Type="raw"
+                Win64="no" />
+        </Property>
 </Include>

--- a/iisca/wix/setupstrings.wxl
+++ b/iisca/wix/setupstrings.wxl
@@ -197,6 +197,7 @@
   <String Id="MetabaseRequired" Overridable="yes">IIS Metabase is required to install [ProductName].</String>
   <String Id="LaunchCondition_32BIT">The 64-bit version of [ProductName] cannot be installed on a 32-bit edition of Microsoft Windows.</String>
   <String Id="LaunchCondition_64BIT">The 32-bit version of [ProductName] cannot be installed on a 64-bit edition of Microsoft Windows.</String>
+  <String Id="LaunchCondition_ARM64">The 64-bit version of [ProductName] cannot be installed on a ARM64 edition of Microsoft Windows.</String>
   <String Id="NetFX2OrGreaterRequired">Microsoft .NET Framework Version 2.0 or greater is required to install [ProductName].</String>
   <String Id="NetFX35OrGreaterRequired">Microsoft .NET Framework Version 3.5 or greater is required to install [ProductName].  Use 'Add Features' under the Server Manager to install Microsoft .Net Version 3.5.</String>
   <String Id="NetFX4OrGreaterRequired">Microsoft .NET Framework Version 4.0 or greater is required to install [ProductName].</String>


### PR DESCRIPTION
- Add property to read the processory architecture value from registyry
- Add error string for blocking x64 installers from installing on ARM64 Windows.
